### PR TITLE
chore: add @samuelgoff as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @samuelgoff


### PR DESCRIPTION
Adds @samuelgoff to every existing CODEOWNERS rule and the catch-all rule without removing current owners.